### PR TITLE
Fix crash when OPENVINO_EXTENSION_PATH is unset

### DIFF
--- a/vcap_utils/vcap_utils/backends/base_openvino.py
+++ b/vcap_utils/vcap_utils/backends/base_openvino.py
@@ -42,6 +42,7 @@ class BaseOpenVINOBackend(BaseBackend):
                                 "requested, but OPENVINO_EXTENSION_PATH "
                                 "is not set. No extensions will be "
                                 "loaded.")
+                cpu_extensions = []
         for cpu_extension in cpu_extensions:
             self.ie.add_extension(cpu_extension, device_name)
 


### PR DESCRIPTION
Fixes a bug where the `cpu_extensions` list would be None if the environment variable was unset, leading to a crash.