### PR TITLE
Switch to using new bytes-based model loading for OpenVINO

### DIFF
--- a/vcap_utils/vcap_utils/backends/base_openvino.py
+++ b/vcap_utils/vcap_utils/backends/base_openvino.py
@@ -65,10 +65,12 @@ class BaseOpenVINOBackend(BaseBackend):
     @classmethod
     def from_bytes(cls, model_bytes: bytes, weights_bytes: bytes,
                    *args, **kwargs):
-        """This method is deprecated. Use the BaseOpenVINOBackend constructor
-        instead.
         """
-        return cls(model=model_bytes, weights=weights_bytes, *args, **kwargs)
+        .. deprecated:: 0.1.4
+           Use the BaseOpenVINOBackend constructor
+        """
+        return cls(model_xml=model_bytes, weights_bin=weights_bytes,
+                   *args, **kwargs)
 
     @abc.abstractmethod
     def parse_results(self, results: np.ndarray, resize: Resize) -> object:

--- a/vcap_utils/vcap_utils/backends/base_openvino.py
+++ b/vcap_utils/vcap_utils/backends/base_openvino.py
@@ -12,13 +12,13 @@ from vcap.backend import BaseBackend
 
 
 class BaseOpenVINOBackend(BaseBackend):
-    def __init__(self, model: bytes,
-                 weights: bytes,
+    def __init__(self, model_xml: bytes,
+                 weights_bin: bytes,
                  device_name: str = "CPU",
                  cpu_extensions: Optional[List[str]] = None):
         """
-        :param model: The XML data defining the OpenVINO model architecture
-        :param weights: The .bin file data defining the model's weights
+        :param model_xml: The XML data defining the OpenVINO model architecture
+        :param weights_bin: The .bin file data defining the model's weights
         :param cpu_extensions:
           None (default): Load extensions from the path specified by the
             OPENVINO_EXTENSION_PATH environment variable (should be set
@@ -50,7 +50,7 @@ class BaseOpenVINOBackend(BaseBackend):
             self.ie.add_extension(cpu_extension, device_name)
 
         self.net = self.ie.read_network(
-            model=model, weights=weights, init_from_buffer=True)
+            model=model_xml, weights=weights_bin, init_from_buffer=True)
 
         # (Unused for now)
         batching_enabled = False


### PR DESCRIPTION
The old method of loading a network with the `IENetwork` constructor has been deprecated in favor of `IECore.read_network`. This new method lets us load a model directly from memory instead of having to write to a temporary file beforehand.

This obsoletes the `BaseOpenVINOBackend.from_bytes` helper method. My plan is to change all capsules in the capsule_zoo and pharmacy repositories to stop using this method, then remove this method as part of a separate PR.