### PR TITLE
Replace setuptools_scm with our own solution

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,18 +35,20 @@ jobs:
       run: |
         pip install --upgrade setuptools wheel twine
     - name: Publish vcap
+      working-directory: ./vcap
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python3 vcap/setup.py sdist bdist_wheel
+        PRE_RELEASE_SUFFIX=$(python3 ../.github/workflows/pre_release_suffix.py) \
+          python3 setup.py sdist bdist_wheel
         python3 -m twine upload dist/*
     - name: Publish vcap-utils
+      working-directory: ./vcap_utils
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        # Clean up from vcap packaging
-        rm -r dist
-        python3 vcap_utils/setup.py sdist bdist_wheel
+        PRE_RELEASE_SUFFIX=$(python3 ../.github/workflows/pre_release_suffix.py) \
+          python3 setup.py sdist bdist_wheel
         python3 -m twine upload dist/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Publish packages
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   deploy:
@@ -40,17 +38,17 @@ jobs:
       working-directory: ./vcap
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         PRE_RELEASE_SUFFIX=$(python3 ../.github/workflows/pre_release_suffix.py) \
           python3 setup.py sdist bdist_wheel
-        python3 -m twine upload --repository testpypi dist/*
+        python3 -m twine upload dist/*
     - name: Publish vcap-utils
       working-directory: ./vcap_utils
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         PRE_RELEASE_SUFFIX=$(python3 ../.github/workflows/pre_release_suffix.py) \
           python3 setup.py sdist bdist_wheel
-        python3 -m twine upload --repository testpypi dist/*
+        python3 -m twine upload dist/*

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Publish packages
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   deploy:
@@ -38,17 +40,17 @@ jobs:
       working-directory: ./vcap
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
       run: |
         PRE_RELEASE_SUFFIX=$(python3 ../.github/workflows/pre_release_suffix.py) \
           python3 setup.py sdist bdist_wheel
-        python3 -m twine upload dist/*
+        python3 -m twine upload --repository testpypi dist/*
     - name: Publish vcap-utils
       working-directory: ./vcap_utils
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
       run: |
         PRE_RELEASE_SUFFIX=$(python3 ../.github/workflows/pre_release_suffix.py) \
           python3 setup.py sdist bdist_wheel
-        python3 -m twine upload dist/*
+        python3 -m twine upload --repository testpypi dist/*

--- a/.github/workflows/pre_release_suffix.py
+++ b/.github/workflows/pre_release_suffix.py
@@ -1,0 +1,33 @@
+"""Prints a suffix that will be appended to the end of the version strings
+for the vcap and vcap-utils packages.
+
+For example, if there have been 3 commits since the last tagged release and the
+current version string in the setup.py is '0.1.3', the suffix will be '.dev3'.
+The resulting package version will then become '0.1.3.dev3'.
+
+For commits that have a tag, this script will print nothing. That way, the
+resulting package will have no pre-release suffix.
+
+Ideally, we would be using setuptools_scm to manage all of this for us.
+Unfortunately, setuptools_scm doesn't work for repositories with multiple
+packages. See: https://github.com/pypa/setuptools_scm/issues/357
+"""
+
+import subprocess
+import re
+import sys
+
+TAG_PATTERN = r"^v\d+\.\d+\.+\d+-?(\d+)?-?(.+)?$"
+
+result = subprocess.run(["git", "describe", "--tags"],
+                        check=True, stdout=subprocess.PIPE, encoding="utf-8")
+
+match = re.match(TAG_PATTERN, result.stdout)
+if match is None:
+    print(f"Could not match tag: '{result.stdout}'", file=sys.stderr)
+    sys.exit(1)
+
+if match.group(1) is not None:
+    print(f".dev{match.group(1)}")
+else:
+    print("")

--- a/vcap/setup.py
+++ b/vcap/setup.py
@@ -1,28 +1,18 @@
 #!/usr/bin/env python3
+import os
+
 from setuptools import setup, find_namespace_packages
 
 test_packages = ["pytest", "mock"]
+
+PRE_RELEASE_SUFFIX = os.environ.get("PRE_RELEASE_SUFFIX", "")
 
 setup(
     name='vcap',
     description="A library for creating OpenVisionCapsules in Python",
     author="Dilili Labs",
     packages=find_namespace_packages(include=["vcap*"]),
-
-    # Pull the package version from Git tags
-    use_scm_version={
-        # Helps setuptools_scm find the repository root
-        "root": "..",
-        "relative_to": __file__,
-        # We want to be able to push these releases to PyPI, which doesn't
-        # support local versions. Local versions are anything after the "+" in
-        # a version string like "0.1.4.dev16+heyguys".
-        "local_scheme": "no-local-version",
-    },
-
-    setup_requires=[
-        "setuptools_scm",
-    ],
+    version="0.1.4" + PRE_RELEASE_SUFFIX,
 
     install_requires=[
         "pycryptodomex==3.9.7",

--- a/vcap_utils/setup.py
+++ b/vcap_utils/setup.py
@@ -1,29 +1,18 @@
 #!/usr/bin/env python3
+import os
+
 from setuptools import setup, find_namespace_packages
 
 test_packages = ["pytest", "mock"]
+
+PRE_RELEASE_SUFFIX = os.environ.get("PRE_RELEASE_SUFFIX", "")
 
 setup(
     name='vcap-utils',
     description="Utilities for creating OpenVisionCapsules easily in Python",
     author="Dilili Labs",
-    packages=find_namespace_packages(
-        include=["vcap_utils*"],
-        exclude=["vcap_utils.tests*"]),
-
-    # Pull the package version from Git tags
-    use_scm_version={
-        "root": "..",
-        "relative_to": __file__,
-        # We want to be able to push these releases to PyPI, which doesn't
-        # support local versions. Local versions are anything after the "+" in
-        # a version string like "0.1.4.dev16+heyguys".
-        "local_scheme": "no-local-version",
-    },
-
-    setup_requires=[
-        "setuptools_scm",
-    ],
+    packages=find_namespace_packages(include=["vcap_utils*"]),
+    version="0.1.4" + PRE_RELEASE_SUFFIX,
 
     install_requires=[
         "vcap",


### PR DESCRIPTION
Unfortunately, setuptools_scm can't work with repositories that have multiple packages right now. Relevant issue: https://github.com/pypa/setuptools_scm/issues/357

Instead, we'll use a workflow that pulls the semver from each package's setup.py with a "dev{revision}" suffix. The revision number is retrieved from `git describe --tags` using the same process that setuptools_scm uses. When a commit has a tag associated with it, there will be no "dev{revision}" suffix applied.

This means we need to remember to increment the setup.py version number after each full release. If someone forgets to do this, pre-releases will be made for the previous version. Not ideal, but it won't break the existing stable release.