### PR TITLE
Improve error messages during capsule loading

### DIFF
--- a/vcap/vcap/loading/capsule_loading.py
+++ b/vcap/vcap/loading/capsule_loading.py
@@ -302,7 +302,12 @@ def _validate_capsule_field(capsule: BaseCapsule,
                             name: str,
                             value: Any,
                             type_: _TYPE_CALLABLE) -> None:
-    if not _check_type(value, type_):
+    if type_ is callable and not callable(value):
+        raise InvalidCapsuleError(
+            f"The capsule has an invalid internal configuration!\n"
+            f"Capsule field {name} must be callable, got {type(value)}",
+            capsule.name)
+    elif not isinstance(value, type_):
         raise InvalidCapsuleError(
             f"The capsule has an invalid internal configuration!\n"
             f"Capsule field {name} must be of type {type_}, got {type(value)}",
@@ -313,16 +318,13 @@ def _validate_backend_field(capsule: BaseCapsule,
                             name: str,
                             value: Any,
                             type_: _TYPE_CALLABLE) -> None:
-    if not _check_type(value, type_):
+    if type_ is callable and not callable(value):
+        raise InvalidCapsuleError(
+            f"The capsule's backend has an invalid configuration!\n"
+            f"Backend field {name} must be callable, got {type(value)}",
+            capsule.name)
+    elif not isinstance(value, type_):
         raise InvalidCapsuleError(
             f"The capsule's backend has an invalid configuration!\n"
             f"Backend field {name} must be of type {type_}, got {type(value)}",
             capsule.name)
-
-
-def _check_type(value: Any, type_: _TYPE_CALLABLE) -> bool:
-    if type_ is callable:
-        # callable isn't actually a type, so we need to give it a special case
-        return callable(value)
-    else:
-        return isinstance(value, type_)

--- a/vcap/vcap/loading/capsule_loading.py
+++ b/vcap/vcap/loading/capsule_loading.py
@@ -266,8 +266,8 @@ def _validate_capsule(capsule: BaseCapsule):
         stream_state = capsule.stream_state
         if not issubclass(stream_state, BaseStreamState):
             raise InvalidCapsuleError(
-                f"The capsule's stream_state field must be a class that "
-                f"subclasses {BaseStreamState.__name__}, got {stream_state}")
+                f"The capsule's stream_state field must be a subclass of "
+                f"{BaseStreamState.__name__}, got {stream_state}")
 
         # Validate that if the capsule is an encoder, it has a threshold option
         if capsule.capability.encoded:

--- a/vcap/vcap/loading/capsule_loading.py
+++ b/vcap/vcap/loading/capsule_loading.py
@@ -5,7 +5,7 @@ import sys
 from io import BytesIO
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Union, Any
 from zipfile import ZipFile
 
 from vcap import BaseCapsule, BaseBackend, BaseStreamState, NodeDescription
@@ -295,7 +295,13 @@ def capsule_module_name(data: bytes) -> str:
     return f"capsule_{hash_}"
 
 
-def _validate_capsule_field(capsule, name, value, type_) -> None:
+_TYPE_CALLABLE = Union[type, callable]
+
+
+def _validate_capsule_field(capsule: BaseCapsule,
+                            name: str,
+                            value: Any,
+                            type_: _TYPE_CALLABLE) -> None:
     if not _check_type(value, type_):
         raise InvalidCapsuleError(
             f"The capsule has an invalid internal configuration!\n"
@@ -303,7 +309,10 @@ def _validate_capsule_field(capsule, name, value, type_) -> None:
             capsule.name)
 
 
-def _validate_backend_field(capsule, name, value, type_) -> None:
+def _validate_backend_field(capsule: BaseCapsule,
+                            name: str,
+                            value: Any,
+                            type_: _TYPE_CALLABLE) -> None:
     if not _check_type(value, type_):
         raise InvalidCapsuleError(
             f"The capsule's backend has an invalid configuration!\n"
@@ -311,7 +320,7 @@ def _validate_backend_field(capsule, name, value, type_) -> None:
             capsule.name)
 
 
-def _check_type(value, type_) -> bool:
+def _check_type(value: Any, type_: _TYPE_CALLABLE) -> bool:
     if type_ is callable:
         # callable isn't actually a type, so we need to give it a special case
         return callable(value)

--- a/vcap/vcap/loading/capsule_loading.py
+++ b/vcap/vcap/loading/capsule_loading.py
@@ -5,7 +5,7 @@ import sys
 from io import BytesIO
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, List, Optional, Union, Any
+from typing import Any, Callable, List, Optional, Union
 from zipfile import ZipFile
 
 from vcap import BaseCapsule, BaseBackend, BaseStreamState, NodeDescription

--- a/vcap/vcap/loading/capsule_loading.py
+++ b/vcap/vcap/loading/capsule_loading.py
@@ -312,7 +312,8 @@ def _validate_backend_field(capsule, name, value, type_) -> None:
 
 
 def _check_type(value, type_) -> bool:
-    if type_ == callable:
+    if type_ is callable:
+        # callable isn't actually a type, so we need to give it a special case
         return callable(value)
     else:
         return isinstance(value, type_)

--- a/vcap/vcap/loading/capsule_loading.py
+++ b/vcap/vcap/loading/capsule_loading.py
@@ -302,11 +302,12 @@ def _validate_capsule_field(capsule: BaseCapsule,
                             name: str,
                             value: Any,
                             type_: _TYPE_CALLABLE) -> None:
-    if type_ is callable and not callable(value):
-        raise InvalidCapsuleError(
-            f"The capsule has an invalid internal configuration!\n"
-            f"Capsule field {name} must be callable, got {type(value)}",
-            capsule.name)
+    if type_ is callable:
+        if not callable(value):
+            raise InvalidCapsuleError(
+                f"The capsule has an invalid internal configuration!\n"
+                f"Capsule field {name} must be callable, got {type(value)}",
+                capsule.name)
     elif not isinstance(value, type_):
         raise InvalidCapsuleError(
             f"The capsule has an invalid internal configuration!\n"
@@ -318,11 +319,12 @@ def _validate_backend_field(capsule: BaseCapsule,
                             name: str,
                             value: Any,
                             type_: _TYPE_CALLABLE) -> None:
-    if type_ is callable and not callable(value):
-        raise InvalidCapsuleError(
-            f"The capsule's backend has an invalid configuration!\n"
-            f"Backend field {name} must be callable, got {type(value)}",
-            capsule.name)
+    if type_ is callable:
+        if not callable(value):
+            raise InvalidCapsuleError(
+                f"The capsule's backend has an invalid configuration!\n"
+                f"Backend field {name} must be callable, got {type(value)}",
+                capsule.name)
     elif not isinstance(value, type_):
         raise InvalidCapsuleError(
             f"The capsule's backend has an invalid configuration!\n"

--- a/vcap/vcap/loading/capsule_loading.py
+++ b/vcap/vcap/loading/capsule_loading.py
@@ -264,11 +264,10 @@ def _validate_capsule(capsule: BaseCapsule):
 
         # Validate the stream state
         stream_state = capsule.stream_state
-        if not (stream_state is BaseStreamState or
-                BaseStreamState in stream_state.__bases__):
+        if not issubclass(stream_state, BaseStreamState):
             raise InvalidCapsuleError(
                 f"The capsule's stream_state field must be a class that "
-                f"subclasses {BaseStreamState.__name__}")
+                f"subclasses {BaseStreamState.__name__}, got {stream_state}")
 
         # Validate that if the capsule is an encoder, it has a threshold option
         if capsule.capability.encoded:


### PR DESCRIPTION
The old system maintained a list of conditions and included a list of boolean values in the exception if any of the conditions were false. This has the disadvantage of requiring people who see this error to read the code in order to find out what the problem is. This change adds descriptive messages along with the failures.